### PR TITLE
Add Ruby 3.0, 3.1, and head to the CI matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["2.7"]
+        ruby: ["2.7", "3.0", "3.1", ruby-head]
         gemfile: [
           "Gemfile"
         ]

--- a/Gemfile
+++ b/Gemfile
@@ -5,8 +5,6 @@ git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
 # Specify your gem's dependencies in rubocop-md.gemspec
 gemspec
 
-gem "pry-byebug", platform: :mri
-
 local_gemfile = "Gemfile.local"
 
 if File.exist?(local_gemfile)

--- a/test/fixtures/in_flight_parse.rb
+++ b/test/fixtures/in_flight_parse.rb
@@ -1,3 +1,3 @@
 # frozen_string_literal: true
 
-{ 'complex_symbol': 0 }
+{ complex_symbol: 0 }

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -4,11 +4,6 @@ $LOAD_PATH.unshift File.expand_path("../lib", __dir__)
 require "rubocop"
 require "rubocop-md"
 
-begin
-  require "pry-byebug"
-rescue LoadError # rubocop:disable Lint/SuppressedException
-end
-
 RuboCop::Markdown.config_store = RuboCop::ConfigStore.new
 
 module SquigglyHeredoc


### PR DESCRIPTION
In addition to the CI configuration change, this PR:

1. Removes `pry-byebug` as `byebug` is not a supported debugger going forward
2. Fixes a lint in the fixture