### PR TITLE
Fix restore files regression

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
           gemfile: "Gemfile"
         - ruby: "2.6"
           gemfile: "Gemfile"
-        - ruby: "2.7"
+        - ruby: "3.1"
           gemfile: "gemfiles/rubocopmaster.gemfile"
     steps:
     - uses: actions/checkout@v2

--- a/lib/rubocop/markdown/rubocop_ext.rb
+++ b/lib/rubocop/markdown/rubocop_ext.rb
@@ -56,13 +56,16 @@ RuboCop::Runner.prepend(Module.new do
   end
 
   # Run Preprocess.restore if file has been autocorrected
-  def process_file(file)
-    return super unless @options[:auto_correct] && RuboCop::Markdown.markdown_file?(file)
+  def file_finished(file, offenses)
+    unless (
+      @options[:auto_correct] || @options[:autocorrect]
+    ) && RuboCop::Markdown.markdown_file?(file)
+      return super
+    end
 
-    offenses = super
     RuboCop::Markdown::Preprocess.restore!(file)
 
-    offenses
+    super
   end
 end)
 


### PR DESCRIPTION
The `restore!` doesn't work with autocorrect since RuboCop 1.30.0. 

Fixes #14 