### PR TITLE
Ignore non-code offenses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master (unreleased)
 
+- Ignore offenses in non-code source.
+
 ## 1.0.1 (2020-12-28)
 
 - Exclude `EmptyLineBetweenDefs` for MD files.

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ This project was developed to keep [test-prof](https://github.com/test-prof/test
 Add this line to your application's Gemfile:
 
 ```ruby
-gem 'rubocop-md'
+gem "rubocop-md"
 ```
 
 And then execute:
@@ -96,7 +96,7 @@ $ rubocop
 
 Also you can add special rules in the second `.rubocop.yml`
 
-```ruby
+```yml
 # rubocop.yml in docs folder
 
 Metrics/LineLength:
@@ -111,7 +111,7 @@ Lint/Void:
 
 You can use this tricks
 
-```
+```md
 # my_post.md
 
 ... some markdown ...
@@ -122,7 +122,9 @@ You can use this tricks
 def my_poor_method(foo)
   [:a, :b, :c] + ["#{foo}".to_sym]
 end
-``` end of snippet
+```
+
+end of snippet
 
 <span style="display:none;"># rubocop:enable all</span>
 

--- a/test/fixtures/NON_CODE_OFFENSES.md
+++ b/test/fixtures/NON_CODE_OFFENSES.md
@@ -1,0 +1,3 @@
+# No Code
+
+Just a line with a trailining whitespace 

--- a/test/integration_test.rb
+++ b/test/integration_test.rb
@@ -92,6 +92,13 @@ class RuboCop::Markdown::AnalyzeTest < Minitest::Test
     assert_match %r{Inspecting 1 file}, res
     assert_match %r{no offenses detected}, res
   end
+
+  def test_non_code_offenses
+    res = run_rubocop("NON_CODE_OFFENSES.md")
+
+    assert_match %r{Inspecting 1 file}, res
+    assert_match %r{no offenses detected}, res
+  end
 end
 
 class RuboCop::Markdown::AutocorrectTest < Minitest::Test


### PR DESCRIPTION
Some cops check code comments as well (in our case, non-code markdown contents). We should ignore them. For that, we drop offenses for _marked_ lines.

Related to #14 