### PR TITLE
Fix markers remaining in Rails guides

### DIFF
--- a/lib/rubocop/markdown/preprocess.rb
+++ b/lib/rubocop/markdown/preprocess.rb
@@ -14,7 +14,7 @@ module RuboCop
       # Try it: http://rubular.com/r/iJaKBkSrrT
       MD_REGEXP = /^([ \t]*`{3,4})([\w[[:blank:]]]*\n)([\s\S]+?)(^[ \t]*\1[[:blank:]]*\n?)/m.freeze
 
-      MARKER = "<--rubocop/md-->"
+      MARKER = "<--rubocop\/md-->"
 
       # See https://github.com/github/linguist/blob/v5.3.3/lib/linguist/languages.yml#L3925
       RUBY_TYPES = %w[
@@ -55,14 +55,15 @@ module RuboCop
         # We have to restore it.
         def restore!(file)
           contents = File.read(file)
-          contents.gsub!(/^##{MARKER}/m, "")
+          contents.gsub!(/#<--rubocop\/md-->/m, "")
           File.write(file, contents)
         end
       end
 
-      attr_reader :config
+      attr_reader :config, :_file
 
       def initialize(file)
+        @_file = file
         @config = Markdown.config_store.for(file)
       end
 
@@ -86,6 +87,8 @@ module RuboCop
 
           walker.next!
         end
+
+        Preprocess::restore! @_file
 
         parts.join
       end
@@ -127,7 +130,7 @@ module RuboCop
       def comment_lines!(src)
         return if src =~ /\A\n\z/
 
-        src.gsub!(/^(.)/m, "##{MARKER}\\1")
+        src.gsub!(/^(.)/m, "#<--rubocop\/md-->\\1")
       end
     end
   end


### PR DESCRIPTION
This is probably not ready yet, but was necessary to stop this gem from leaving junk in the Rails guides for me.

For more context, I was experimenting with adding this gem to Rails for linting all of the code samples in our guides. However, when using `--autocorrect-all` this would leave `#<--rubocop/md-->` at the beginning of every line and every code block fence.

Happy to clean this up if there is something here, IDK if it's just me.

Additionally, a question I had was with `Layout/IndentationConsistency`, I've had to disable this cop when using the gem because it will raise for things like:

```markdown
  \```ruby
  def foo
  end
  \```
```

It feels like the indentation should match the start of the code fence, but I'm not really sure what's going on there. Would love to learn more! :bow:
