### PR TITLE
Fix broken README

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ Lint/Void:
 
 You can use this tricks
 
-```md
+````md
 # my_post.md
 
 ... some markdown ...
@@ -134,7 +134,7 @@ end of snippet
 <span style="display:none;"># rubocop:enable all</span>
 
 ... continuation of article ...
-```
+````
 
 ## How it works?
 


### PR DESCRIPTION
The layout was broken due to the use of ``` in the README code block.
I fixed the layout breaks by using ```` for the outermost code block.