### PR TITLE
Fixes the case, when config_store is nil

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -2,7 +2,7 @@ require "bundler/gem_tasks"
 require "rake/testtask"
 require "rubocop/rake_task"
 
-Rake::TestTask.new(:test) do |t|
+Rake::TestTask.new(:rubocop_md_tests) do |t|
   t.libs << "test"
   t.libs << "lib"
   t.warning = false
@@ -10,5 +10,16 @@ Rake::TestTask.new(:test) do |t|
 end
 
 RuboCop::RakeTask.new
+
+task :test do
+  ENV["MD_LOAD_MODE"] = "inline"
+  $stdout.puts "⚙️ Runs rubocop with '-r rubocop_md' options"
+  Rake::Task[:rubocop_md_tests].invoke
+
+  ENV["MD_LOAD_MODE"] = "config"
+  $stdout.puts "⚙️ Runs rubocop with 'required rubocop_md' section in .rubocop.yml"
+  Rake::Task[:rubocop_md_tests].reenable
+  Rake::Task[:rubocop_md_tests].invoke
+end
 
 task default: [:rubocop, :test]

--- a/lib/rubocop/markdown/rubocop_ext.rb
+++ b/lib/rubocop/markdown/rubocop_ext.rb
@@ -42,9 +42,10 @@ RuboCop::Markdown.inject!
 
 RuboCop::Runner.prepend(Module.new do
   # Set config store for Markdown
-  def initialize(*args)
-    super
+  def get_processed_source(*args)
     RuboCop::Markdown.config_store = @config_store
+
+    super
   end
 
   # Do not cache markdown files, 'cause cache doesn't know about processing.

--- a/test/fixtures/.rubocop.yml
+++ b/test/fixtures/.rubocop.yml
@@ -1,0 +1,5 @@
+inherit_from:
+  - "../../.rubocop.yml"
+
+require:
+  - "rubocop-md"

--- a/test/fixtures/configs/no_autodetect.yml
+++ b/test/fixtures/configs/no_autodetect.yml
@@ -1,4 +1,4 @@
-inherit_from: "../../../.rubocop.yml"
+inherit_from: "../.rubocop.yml"
 
 Markdown:
   Autodetect: false

--- a/test/fixtures/configs/no_warn_invalid.yml
+++ b/test/fixtures/configs/no_warn_invalid.yml
@@ -1,4 +1,5 @@
-inherit_from: "../../../.rubocop.yml"
+inherit_from: "../.rubocop.yml"
 
 Markdown:
   WarnInvalid: false
+

--- a/test/integration_test.rb
+++ b/test/integration_test.rb
@@ -6,11 +6,11 @@ require "fileutils"
 
 module RuboCopRunner
   def run_rubocop(path, options: "")
-    md_path = File.expand_path("../lib/rubocop-md.rb", __dir__)
     output, _status = Open3.capture2(
-      "bundle exec rubocop -r #{md_path} #{options} #{path}",
+      "bundle exec rubocop #{options} #{path}",
       chdir: File.join(__dir__, "fixtures")
     )
+
     output
   end
 end
@@ -20,6 +20,14 @@ class RuboCop::Markdown::AnalyzeTest < Minitest::Test
 
   def test_single_snippet_file
     res = run_rubocop("single_snippet.md")
+
+    assert_match %r{Inspecting 1 file}, res
+    assert_match %r{1 offense detected}, res
+    assert_match %r{Style/StringLiterals}, res
+  end
+
+  def test_file_with_format_options
+    res = run_rubocop("single_snippet.md", options: "--format progress")
 
     assert_match %r{Inspecting 1 file}, res
     assert_match %r{1 offense detected}, res

--- a/test/integration_test.rb
+++ b/test/integration_test.rb
@@ -5,13 +5,30 @@ require "open3"
 require "fileutils"
 
 module RuboCopRunner
+  MD_LOAD_INLINE_MODE = "inline"
+
   def run_rubocop(path, options: "")
     output, _status = Open3.capture2(
-      "bundle exec rubocop #{options} #{path}",
+      cmd_command_by_env(path, options),
       chdir: File.join(__dir__, "fixtures")
     )
 
     output
+  end
+
+  private
+
+  def cmd_command_by_env(path, options)
+    cmd_command = "bundle exec rubocop"
+    load_mode = ENV.fetch("MD_LOAD_MODE", MD_LOAD_INLINE_MODE)
+
+    if load_mode == MD_LOAD_INLINE_MODE
+      md_path = File.expand_path("../lib/rubocop-md.rb", __dir__)
+
+      cmd_command = "#{cmd_command} -r #{md_path}"
+    end
+
+    "#{cmd_command} #{options} #{path}"
   end
 end
 


### PR DESCRIPTION
This problem appeared when `rubocop-md` loaded via `.rubocop.yml` and used `--formater` because the `Runner` is created before plugins (`rubocop_ext`) is loaded.

Fixes #22

Also, I rewrote the running test through the `require` section in `.rubocop.yml.`