### PR TITLE
Simplify markdown parsing

### DIFF
--- a/lib/rubocop/markdown/preprocess.rb
+++ b/lib/rubocop/markdown/preprocess.rb
@@ -12,7 +12,13 @@ module RuboCop
       # Only recognizes backticks-style code blocks.
       #
       # Try it: https://rubular.com/r/YMqSWiBuh2TKIJ
-      MD_REGEXP = /^([ \t]*`{3,4})([\w[[:blank:]]+]*)?\n([\s\S]+?)(^[ \t]*\1[[:blank:]]*\n?)|(^.*$)/.freeze
+      MD_REGEXP = /
+        ^([[:blank:]]*`{3,4}) # Match opening backticks
+        ([\w[[:blank:]]+]*)?\n # Match the code block syntax
+        ([\s\S]+?) # Match everything inside the code block
+        (^[[:blank:]]*\1[[:blank:]]*\n?) # Match closing backticks
+        |(^.*$) # If we are not in a codeblock, match the whole line
+      /x.freeze
 
       MARKER = "<--rubocop/md-->"
 

--- a/test/integration_test.rb
+++ b/test/integration_test.rb
@@ -125,7 +125,6 @@ class RuboCop::Markdown::AnalyzeTest < Minitest::Test
 end
 
 class RuboCop::Markdown::AutocorrectTest < Minitest::Test
-  using SquigglyHeredoc
   include RuboCopRunner
 
   def fixture_name
@@ -146,7 +145,7 @@ class RuboCop::Markdown::AutocorrectTest < Minitest::Test
 
   def test_autocorrect_single_snippet
     prepare_test(
-      <<-CODE.squiggly
+      <<~CODE
         # Before All
 
         Rails has a great feature – `transactional_tests`.
@@ -166,7 +165,7 @@ class RuboCop::Markdown::AutocorrectTest < Minitest::Test
       CODE
     )
 
-    expected = <<-CODE.squiggly
+    expected = <<~CODE
       # Before All
 
       Rails has a great feature – `transactional_tests`.
@@ -194,7 +193,7 @@ class RuboCop::Markdown::AutocorrectTest < Minitest::Test
 
   def test_autocorrect_multiple_snippets
     prepare_test(
-      <<-CODE.squiggly
+      <<~CODE
         ```ruby
         # bad
         it { is_expected.to be_success }
@@ -225,7 +224,7 @@ class RuboCop::Markdown::AutocorrectTest < Minitest::Test
       CODE
     )
 
-    expected = <<-CODE.squiggly
+    expected = <<~CODE
       ```ruby
       # bad
       it { is_expected.to be_success }
@@ -264,7 +263,7 @@ class RuboCop::Markdown::AutocorrectTest < Minitest::Test
 
   def test_autocorrect_with_compound_snippets
     prepare_test(
-      <<-CODE.squiggly
+      <<~CODE
         Passing an array of symbols is also acceptable.
 
         ```ruby
@@ -307,7 +306,7 @@ class RuboCop::Markdown::AutocorrectTest < Minitest::Test
       CODE
     )
 
-    expected = <<-CODE.squiggly
+    expected = <<~CODE
       Passing an array of symbols is also acceptable.
 
       ```ruby

--- a/test/preprocess_test.rb
+++ b/test/preprocess_test.rb
@@ -2,8 +2,6 @@
 
 require "test_helper"
 
-using SquigglyHeredoc
-
 class RuboCop::Markdown::PreprocessTest < Minitest::Test
   def subject
     RuboCop::Markdown::Preprocess.new("test.md").tap do |obj|
@@ -15,13 +13,13 @@ class RuboCop::Markdown::PreprocessTest < Minitest::Test
   end
 
   def test_no_code_snippets
-    source = <<-SOURCE.squiggly
+    source = <<~SOURCE
       # Header
 
       Boby text
     SOURCE
 
-    expected = <<-SOURCE.squiggly
+    expected = <<~SOURCE
       #<--rubocop/md--># Header
       #<--rubocop/md-->
       #<--rubocop/md-->Boby text
@@ -31,7 +29,7 @@ class RuboCop::Markdown::PreprocessTest < Minitest::Test
   end
 
   def test_with_one_snippet
-    source = <<-SOURCE.squiggly
+    source = <<~SOURCE
       # Header
 
       Code example:
@@ -45,7 +43,7 @@ class RuboCop::Markdown::PreprocessTest < Minitest::Test
       ```
     SOURCE
 
-    expected = <<-SOURCE.squiggly
+    expected = <<~SOURCE
       #<--rubocop/md--># Header
       #<--rubocop/md-->
       #<--rubocop/md-->Code example:
@@ -63,7 +61,7 @@ class RuboCop::Markdown::PreprocessTest < Minitest::Test
   end
 
   def test_only_snippet
-    source = <<-SOURCE.squiggly
+    source = <<~SOURCE
       ```
       class Test < Minitest::Test
         def test_valid
@@ -73,7 +71,7 @@ class RuboCop::Markdown::PreprocessTest < Minitest::Test
       ```
     SOURCE
 
-    expected = <<-SOURCE.squiggly
+    expected = <<~SOURCE
       #<--rubocop/md-->```
       class Test < Minitest::Test
         def test_valid
@@ -87,7 +85,7 @@ class RuboCop::Markdown::PreprocessTest < Minitest::Test
   end
 
   def test_many_snippets
-    source = <<-SOURCE.squiggly
+    source = <<~SOURCE
       # Header
 
       Code example:
@@ -111,7 +109,7 @@ class RuboCop::Markdown::PreprocessTest < Minitest::Test
       ```
     SOURCE
 
-    expected = <<-SOURCE.squiggly
+    expected = <<~SOURCE
       #<--rubocop/md--># Header
       #<--rubocop/md-->
       #<--rubocop/md-->Code example:
@@ -139,7 +137,7 @@ class RuboCop::Markdown::PreprocessTest < Minitest::Test
   end
 
   def test_invalid_syntax
-    source = <<-SOURCE.squiggly
+    source = <<~SOURCE
       # Header
 
       Code example:
@@ -153,7 +151,7 @@ class RuboCop::Markdown::PreprocessTest < Minitest::Test
       ```
     SOURCE
 
-    expected = <<-SOURCE.squiggly
+    expected = <<~SOURCE
       #<--rubocop/md--># Header
       #<--rubocop/md-->
       #<--rubocop/md-->Code example:
@@ -171,7 +169,7 @@ class RuboCop::Markdown::PreprocessTest < Minitest::Test
   end
 
   def test_non_ruby_snippet
-    source = <<-SOURCE.squiggly
+    source = <<~SOURCE
       # Header
 
       Code example:
@@ -182,7 +180,7 @@ class RuboCop::Markdown::PreprocessTest < Minitest::Test
       ```
     SOURCE
 
-    expected = <<-SOURCE.squiggly
+    expected = <<~SOURCE
       #<--rubocop/md--># Header
       #<--rubocop/md-->
       #<--rubocop/md-->Code example:
@@ -197,7 +195,7 @@ class RuboCop::Markdown::PreprocessTest < Minitest::Test
   end
 
   def test_ambigious_non_ruby_snippet
-    source = <<-SOURCE.squiggly
+    source = <<~SOURCE
       # Header
 
       ```ruby
@@ -221,7 +219,7 @@ class RuboCop::Markdown::PreprocessTest < Minitest::Test
       ```
     SOURCE
 
-    expected = <<-SOURCE.squiggly
+    expected = <<~SOURCE
       #<--rubocop/md--># Header
       #<--rubocop/md-->
       #<--rubocop/md-->```ruby

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -13,14 +13,4 @@ require "rubocop-md"
 
 RuboCop::Markdown.config_store = RuboCop::ConfigStore.new
 
-module SquigglyHeredoc
-  refine String do
-    def squiggly
-      min = scan(/^[ \t]*(?=\S)/).min
-      indent = min ? min.size : 0
-      gsub(/^[ \t]{#{indent}}/, "")
-    end
-  end
-end
-
 require "minitest/autorun"


### PR DESCRIPTION
While looking into the backtick issue I gave the code a lookover and suspected something with the regex logic being wrong.

I found the logic for that to be pretty hard to grasp/follow. I have refactored the code to hopefully be easier to understand.
Instead of going through the elements one by one in a loop and inquiring which step we are at, just use the match results from the regex.

The regex now matches everything which means we can branch on the match data and learn if we are in markdown or a codeblock, handling that as appropriate. The state is entirely contained within one iteration.

I benchmarked this and performance is on par with the current implementation.