### PR TITLE
Update md extensions list

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -2,110 +2,81 @@ Markdown:
   WarnInvalid: true
   Autodetect: true
 
-Layout/CommentIndentation:
+# Keep in sync with MARKDOWN_EXTENSIONS
+Layout/CommentIndentation: &markdown_excludes
   Exclude:
     - '**/*.md'
+    - '**/*.livemd'
     - '**/*.markdown'
+    - '**/*.mdown'
+    - '**/*.mdwn'
+    - '**/*.mdx'
+    - '**/*.mkd'
+    - '**/*.mkdn'
+    - '**/*.mkdown'
+    - '**/*.ronn'
+    - '**/*.scd'
+    - '**/*.workbook'
 
 Layout/LeadingCommentSpace:
-  Exclude:
-    - '**/*.md'
-    - '**/*.markdown'
+  <<: *markdown_excludes
 
 Layout/TrailingBlankLines:
-  Exclude:
-    - '**/*.md'
-    - '**/*.markdown'
+  <<: *markdown_excludes
 
 Layout/TrailingEmptyLines:
-  Exclude:
-    - '**/*.md'
-    - '**/*.markdown'
+  <<: *markdown_excludes
 
 Layout/EmptyLineBetweenDefs:
-  Exclude:
-    - '**/*.md'
-    - '**/*.markdown'
+  <<: *markdown_excludes
 
 Lint/DuplicateRequire:
-  Exclude:
-    - '**/*.md'
-    - '**/*.markdown'
+  <<: *markdown_excludes
 
 Lint/DuplicateMethods:
-  Exclude:
-    - '**/*.md'
-    - '**/*.markdown'
+  <<: *markdown_excludes
 
 Lint/RedundantCopDisableDirective:
-  Exclude:
-    - '**/*.md'
-    - '**/*.markdown'
+  <<: *markdown_excludes
 
 Lint/RedundantCopEnableDirective:
-  Exclude:
-    - '**/*.md'
-    - '**/*.markdown'
+  <<: *markdown_excludes
 
 Lint/RedundantRequireStatement:
-  Exclude:
-    - '**/*.md'
-    - '**/*.markdown'
+  <<: *markdown_excludes
 
 Lint/UnusedMethodArgument:
-  Exclude:
-    - '**/*.md'
-    - '**/*.markdown'
+  <<: *markdown_excludes
 
 Lint/UnusedBlockArgument:
-  Exclude:
-    - '**/*.md'
-    - '**/*.markdown'
+  <<: *markdown_excludes
 
 Lint/UselessAssignment:
-  Exclude:
-    - '**/*.md'
-    - '**/*.markdown'
+  <<: *markdown_excludes
 
 Lint/UselessMethodDefinition:
-  Exclude:
-    - '**/*.md'
-    - '**/*.markdown'
+  <<: *markdown_excludes
 
 Lint/UselessAccessModifier:
-  Exclude:
-    - '**/*.md'
-    - '**/*.markdown'
+  <<: *markdown_excludes
 
 Lint/Void:
-  Exclude:
-    - '**/*.md'
-    - '**/*.markdown'
+  <<: *markdown_excludes
 
 Naming/FileName:
-  Exclude:
-    - '**/*.md'
-    - '**/*.markdown'
+  <<: *markdown_excludes
 
 Style/AsciiComments:
-  Exclude:
-    - '**/*.md'
-    - '**/*.markdown'
+  <<: *markdown_excludes
 
 Style/Documentation:
-  Exclude:
-    - '**/*.md'
-    - '**/*.markdown'
+  <<: *markdown_excludes
 
 Style/CommentAnnotation:
-  Exclude:
-    - '**/*.md'
-    - '**/*.markdown'
+  <<: *markdown_excludes
 
 Style/FrozenStringLiteralComment:
-  Exclude:
-    - '**/*.md'
-    - '**/*.markdown'
+  <<: *markdown_excludes
 
 Layout/LineLength:
   IgnoredPatterns:

--- a/lib/rubocop/markdown/rubocop_ext.rb
+++ b/lib/rubocop/markdown/rubocop_ext.rb
@@ -2,10 +2,11 @@
 
 module RuboCop
   module Markdown # :nodoc:
-    # According to Linguist.
-    # See https://github.com/github/linguist/blob/96ca71ab99c2f9928d5d69f4c08fd2a51440d045/lib/linguist/languages.yml#L3065-L3083
+    # According to Linguist. mdx was dropped but is being kept for backwards compatibility.
+    # See https://github.com/github-linguist/linguist/blob/8c380f360ce00b95fa08d14ce0ebccd481af1b33/lib/linguist/languages.yml#L4088-L4098
     MARKDOWN_EXTENSIONS = %w[
       .md
+      .livemd
       .markdown
       .mdown
       .mdwn
@@ -14,6 +15,7 @@ module RuboCop
       .mkdn
       .mkdown
       .ronn
+      .scd
       .workbook
     ].freeze
 

--- a/lib/rubocop/markdown/rubocop_ext.rb
+++ b/lib/rubocop/markdown/rubocop_ext.rb
@@ -4,6 +4,7 @@ module RuboCop
   module Markdown # :nodoc:
     # According to Linguist. mdx was dropped but is being kept for backwards compatibility.
     # See https://github.com/github-linguist/linguist/blob/8c380f360ce00b95fa08d14ce0ebccd481af1b33/lib/linguist/languages.yml#L4088-L4098
+    # Keep in sync with config/default.yml
     MARKDOWN_EXTENSIONS = %w[
       .md
       .livemd

--- a/test/fixtures/file_extensions/11.livemd
+++ b/test/fixtures/file_extensions/11.livemd
@@ -1,0 +1,3 @@
+```ruby
+puts 'John'
+```

--- a/test/fixtures/file_extensions/12.scd
+++ b/test/fixtures/file_extensions/12.scd
@@ -1,0 +1,3 @@
+```ruby
+puts 'John'
+```

--- a/test/integration_test.rb
+++ b/test/integration_test.rb
@@ -107,6 +107,8 @@ class RuboCop::Markdown::AnalyzeTest < Minitest::Test
     assert_includes res, "file_extensions/08.mkdown:"
     assert_includes res, "file_extensions/09.ronn:"
     assert_includes res, "file_extensions/10.workbook:"
+    assert_includes res, "file_extensions/11.livemd:"
+    assert_includes res, "file_extensions/12.scd:"
   end
 
   def test_in_flight_parsing


### PR DESCRIPTION
Adds two extensions that are being considered as markdown.

I also updated the config excludes to include all extensions, without this some tests fail with infinite loops and such on these extensions. This tells me that nobody actually uses this for them but if support is there it should just work.

I use yaml anchors for this. Rubocop has added support for them with version 0.75 https://github.com/rubocop/rubocop/blob/master/CHANGELOG.md#0750-2019-09-30