### PR TITLE
Fix incompatibility with RuboCop extensions that modify Include/Exclude for cops

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -1,3 +1,8 @@
+inherit_mode:
+  merge:
+    - Include
+    - Exclude
+
 Markdown:
   WarnInvalid: true
   Autodetect: true


### PR DESCRIPTION
Consider this:
* A different extension (like rubocop-erb) gets loaded first and modifies a cops Exclude list
* rubocop-md gets loaded and also modifies the same cops exclude list
* rubocop-md discards the changes from rubocop-erb because the configs aren't being properly merged

For example, when adding rubocop-erb to the rails repository there are about 1.5k offenses. With this change there are only about 10% since the excludes from rubocop-erb are properly applied.

I tried adding a test for this but couldn't figure out how to do that properly.

CI for ruby-head is failing until minitest releases a new version, see https://github.com/minitest/minitest/commit/5f5c2111f36658fd2636b108b8327ce4b2f3cf8d