### PR TITLE
Add ruby 3.3 to CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,12 +17,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["2.6", "2.7", "3.0", "3.1", "3.2", ruby-head, jruby]
+        ruby: ["2.6", "2.7", "3.0", "3.1", "3.2", "3.3", ruby-head, jruby]
         rubocop_version: [""]
         include:
         - ruby: "2.6"
           rubocop_version: "'1.45.0'"
-        - ruby: "3.2"
+        - ruby: "3.3"
           rubocop_version: "github: 'rubocop/rubocop'"
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
CI for ruby-head is failing until minitest releases a new version, see https://github.com/minitest/minitest/commit/5f5c2111f36658fd2636b108b8327ce4b2f3cf8d