### PR TITLE
Remove mdx support as it appears bugged

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -10,18 +10,17 @@ Markdown:
 # Keep in sync with MARKDOWN_EXTENSIONS
 Layout/CommentIndentation: &markdown_excludes
   Exclude:
-    - '**/*.md'
-    - '**/*.livemd'
-    - '**/*.markdown'
-    - '**/*.mdown'
-    - '**/*.mdwn'
-    - '**/*.mdx'
-    - '**/*.mkd'
-    - '**/*.mkdn'
-    - '**/*.mkdown'
-    - '**/*.ronn'
-    - '**/*.scd'
-    - '**/*.workbook'
+    - "**/*.md"
+    - "**/*.livemd"
+    - "**/*.markdown"
+    - "**/*.mdown"
+    - "**/*.mdwn"
+    - "**/*.mkd"
+    - "**/*.mkdn"
+    - "**/*.mkdown"
+    - "**/*.ronn"
+    - "**/*.scd"
+    - "**/*.workbook"
 
 Layout/LeadingCommentSpace:
   <<: *markdown_excludes

--- a/lib/rubocop/markdown/rubocop_ext.rb
+++ b/lib/rubocop/markdown/rubocop_ext.rb
@@ -2,7 +2,6 @@
 
 module RuboCop
   module Markdown # :nodoc:
-    # According to Linguist. mdx was dropped but is being kept for backwards compatibility.
     # See https://github.com/github-linguist/linguist/blob/8c380f360ce00b95fa08d14ce0ebccd481af1b33/lib/linguist/languages.yml#L4088-L4098
     # Keep in sync with config/default.yml
     MARKDOWN_EXTENSIONS = %w[
@@ -11,7 +10,6 @@ module RuboCop
       .markdown
       .mdown
       .mdwn
-      .mdx
       .mkd
       .mkdn
       .mkdown

--- a/test/fixtures/file_extensions/05.mdx
+++ b/test/fixtures/file_extensions/05.mdx
@@ -1,3 +1,0 @@
-```ruby
-puts 'John'
-```

--- a/test/integration_test.rb
+++ b/test/integration_test.rb
@@ -68,7 +68,6 @@ class RuboCop::Markdown::AnalyzeTest < Minitest::Test
     assert_includes res, "file_extensions/02.markdown:"
     assert_includes res, "file_extensions/03.mdown:"
     assert_includes res, "file_extensions/04.mdwn:"
-    assert_includes res, "file_extensions/05.mdx:"
     assert_includes res, "file_extensions/06.mkd:"
     assert_includes res, "file_extensions/07.mkdn:"
     assert_includes res, "file_extensions/08.mkdown:"


### PR DESCRIPTION
Proposing we remove `mdx` support as it appears bugged re: the following issue.
- https://github.com/rubocop/rubocop-md/issues/37