### PR TITLE
Suppress RuboCop's deprecation warning

### DIFF
--- a/test/markdown_assertions.rb
+++ b/test/markdown_assertions.rb
@@ -71,7 +71,7 @@ module RuboCop
       end
 
       def _investigate(_cop, processed_source)
-        team = RuboCop::Cop::Team.new(registry.cops, configuration, raise_error: true, autocorrect: true)
+        team = RuboCop::Cop::Team.mobilize(registry.cops, configuration, raise_error: true, autocorrect: true)
         report = team.investigate(processed_source)
         @last_corrector = report.correctors.compact.first || RuboCop::Cop::Corrector.new(processed_source)
         report.offenses


### PR DESCRIPTION
Follow up https://github.com/rubocop/rubocop/pull/13244.

This PR suppresses the following RuboCop's deprecation warning:

```console
$ bundle exec rake
/Users/koic/src/github.com/rubocop/rubocop-md/test/markdown_assertions.rb:74:
warning: `Team.new` with cop classes is deprecated. Use `Team.mobilize` instead.
```