### PR TITLE
Pluginfy rubocop-md

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,12 +17,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["2.6", "2.7", "3.0", "3.1", "3.2", "3.3", ruby-head, jruby]
+        ruby: ["2.7", "3.0", "3.1", "3.2", "3.3", "3.4", ruby-head, jruby]
         rubocop_version: [""]
         include:
-        - ruby: "2.6"
-          rubocop_version: "'1.45.0'"
-        - ruby: "3.3"
+        - ruby: "2.7"
+          rubocop_version: "'1.72.1'"
+        - ruby: "3.4"
           rubocop_version: "github: 'rubocop/rubocop'"
     steps:
     - uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -39,16 +39,16 @@ Or install it yourself as:
 
 ### Command line
 
-Just require `rubocop-md` in your command:
+Just require `rubocop-md` plugin in your command:
 
 ```sh
-rubocop -r "rubocop-md" ./lib
+rubocop --plugin "rubocop-md" ./lib
 ```
 
 Autocorrect works too:
 
 ```sh
-rubocop -r "rubocop-md" -a ./lib
+rubocop --plugin "rubocop-md" -a ./lib
 ```
 
 ### Configuration
@@ -64,7 +64,7 @@ At first, add `rubocop-md` to your main `.rubocop.yml`:
 ```yml
 # .rubocop.yml
 
-require:
+plugins:
   - "rubocop-md"
 ```
 

--- a/lib/rubocop/markdown.rb
+++ b/lib/rubocop/markdown.rb
@@ -11,5 +11,6 @@ module RuboCop
 
     require_relative "markdown/preprocess"
     require_relative "markdown/rubocop_ext" if defined?(::RuboCop::ProcessedSource)
+    require_relative "markdown/plugin"
   end
 end

--- a/lib/rubocop/markdown/plugin.rb
+++ b/lib/rubocop/markdown/plugin.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require "lint_roller"
+
+module RuboCop
+  module Markdown
+    # A plugin that integrates rubocop-md with RuboCop's plugin system.
+    class Plugin < LintRoller::Plugin
+      def about
+        LintRoller::About.new(
+          name: "rubocop-md",
+          version: VERSION,
+          homepage: "https://github.com/rubocop/rubocop-md",
+          description: "Run RuboCop against your Markdown files to make sure " \
+                       "that code examples follow style guidelines."
+        )
+      end
+
+      def supported?(context)
+        context.engine == :rubocop
+      end
+
+      def rules(_context)
+        LintRoller::Rules.new(
+          type: :path,
+          config_format: :rubocop,
+          value: Pathname.new(__dir__).join("../../../config/default.yml")
+        )
+      end
+    end
+  end
+end

--- a/lib/rubocop/markdown/rubocop_ext.rb
+++ b/lib/rubocop/markdown/rubocop_ext.rb
@@ -24,25 +24,12 @@ module RuboCop
     class << self
       attr_accessor :config_store
 
-      # Merge markdown config into default configuration
-      # See https://github.com/backus/rubocop-rspec/blob/master/lib/rubocop/rspec/inject.rb
-      def inject!
-        path = CONFIG_DEFAULT.to_s
-        hash = ConfigLoader.send(:load_yaml_configuration, path)
-        config = Config.new(hash, path)
-        puts "configuration from #{path}" if ConfigLoader.debug?
-        config = ConfigLoader.merge_with_default(config, path)
-        ConfigLoader.instance_variable_set(:@default_configuration, config)
-      end
-
       def markdown_file?(file)
         MARKDOWN_EXTENSIONS.include?(File.extname(file))
       end
     end
   end
 end
-
-RuboCop::Markdown.inject!
 
 RuboCop::Runner.prepend(Module.new do
   # Set config store for Markdown

--- a/rubocop-md.gemspec
+++ b/rubocop-md.gemspec
@@ -8,8 +8,8 @@ Gem::Specification.new do |spec|
   spec.authors       = ["Vladimir Dementyev"]
   spec.email         = ["dementiev.vm@gmail.com"]
 
-  spec.summary       = %q{Run Rubocop against your Markdown files to make sure that code examples follow style guidelines.}
-  spec.description   = %q{Run Rubocop against your Markdown files to make sure that code examples follow style guidelines.}
+  spec.summary       = %q{Run RuboCop against your Markdown files to make sure that code examples follow style guidelines.}
+  spec.description   = %q{Run RuboCop against your Markdown files to make sure that code examples follow style guidelines.}
   spec.homepage      = "https://github.com/rubocop/rubocop-md"
   spec.license       = "MIT"
 
@@ -23,11 +23,14 @@ Gem::Specification.new do |spec|
     "source_code_uri" => "http://github.com/rubocop/rubocop-md"
   }
 
-  spec.required_ruby_version = ">= 2.6.0"
+  spec.metadata['default_lint_roller_plugin'] = 'RuboCop::Markdown::Plugin'
+
+  spec.required_ruby_version = ">= 2.7.0"
 
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "rubocop", ">= 1.45"
+  spec.add_runtime_dependency 'lint_roller', '~> 1.1'
+  spec.add_runtime_dependency "rubocop", ">= 1.72.1"
 
   spec.add_development_dependency "bundler", ">= 1.15"
   spec.add_development_dependency "rake", ">= 13.0"

--- a/test/fixtures/.rubocop.yml
+++ b/test/fixtures/.rubocop.yml
@@ -1,5 +1,5 @@
 inherit_from:
   - "../../.rubocop.yml"
 
-require:
+plugins:
   - "rubocop-md"

--- a/test/fixtures/configs/config_with_require.yml
+++ b/test/fixtures/configs/config_with_require.yml
@@ -1,4 +1,4 @@
 inherit_from: "../../../.rubocop.yml"
 
-require:
+plugins:
   - "rubocop-md"

--- a/test/integration_test.rb
+++ b/test/integration_test.rb
@@ -6,10 +6,9 @@ require "fileutils"
 
 module RuboCopRunner
   def run_rubocop(path, options: "", config: nil)
-    md_path = File.expand_path("../lib/rubocop-md.rb", __dir__)
     md_config_path = File.expand_path("./fixtures/.rubocop.yml", __dir__)
 
-    options = "#{options} -r #{md_path}" if ENV["MD_LOAD_MODE"] == "options"
+    options = "#{options} --plugin rubocop-md" if ENV["MD_LOAD_MODE"] == "options"
 
     if ENV["MD_LOAD_MODE"] == "config"
       # Add "_with_require" suffix

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -3,9 +3,9 @@
 $LOAD_PATH.unshift File.expand_path("../lib", __dir__)
 
 if ENV["MD_LOAD_MODE"] == "options"
-  $stdout.puts "⚙️ Run rubocop with '-r rubocop-md' options"
+  $stdout.puts "⚙️ Run rubocop with '--plugin rubocop-md' options"
 elsif ENV["MD_LOAD_MODE"] == "config"
-  $stdout.puts "⚙️ Run rubocop with 'require: - rubocop-md' in .rubocop.yml"
+  $stdout.puts "⚙️ Run rubocop with 'plugins: - rubocop-md' in .rubocop.yml"
 end
 
 require "minitest/autorun"
@@ -14,5 +14,10 @@ require "rubocop"
 require "rubocop_assertions"
 require "markdown_assertions"
 require "rubocop-md"
+
+# NOTE: Since a custom testing framework is used, the following abstraction
+# for plugin callbacks during testing is not implemented yet.
+# https://github.com/rubocop/rubocop/pull/13840
+RuboCop::Plugin.integrate_plugins(RuboCop::Config.new, ["rubocop-md"])
 
 RuboCop::Markdown.config_store = RuboCop::ConfigStore.new


### PR DESCRIPTION
This PR adds support for RuboCop's Plugin feature.

It replaces the ad-hoc `Inject` with RuboCop plugins introduced in RuboCop 1.72. Additionally, since RuboCop already requires Ruby 2.7 or higher as its runtime, the `required_ruby_version` will be updated to 2.7.

Follow-up https://github.com/rubocop/rubocop/pull/13792