### PR TITLE
Support code blocks with "metadata"

### DIFF
--- a/lib/rubocop/markdown/preprocess.rb
+++ b/lib/rubocop/markdown/preprocess.rb
@@ -94,7 +94,7 @@ module RuboCop
 
       # Check codeblack attribute if it's defined and of Ruby type
       def ruby?(syntax)
-        RUBY_TYPES.include?(syntax)
+        RUBY_TYPES.include?(syntax.split.first)
       end
 
       # Try to parse with Ripper

--- a/test/preprocess_test.rb
+++ b/test/preprocess_test.rb
@@ -243,6 +243,38 @@ class RuboCop::Markdown::PreprocessTest < Minitest::Test
     assert_equal expected, subject.call(source)
   end
 
+  def test_ruby_snippet_with_metadata
+    source = <<~SOURCE
+      # Header
+
+      Code example:
+
+      ```ruby test_valid_example
+      class Test < Minitest::Test
+        def test_valid
+          assert false
+        end
+      end
+      ```
+    SOURCE
+
+    expected = <<~SOURCE
+      #<--rubocop/md--># Header
+      #<--rubocop/md-->
+      #<--rubocop/md-->Code example:
+      #<--rubocop/md-->
+      #<--rubocop/md-->```ruby test_valid_example
+      class Test < Minitest::Test
+        def test_valid
+          assert false
+        end
+      end
+      #<--rubocop/md-->```
+    SOURCE
+
+    assert_equal expected, subject.call(source)
+  end
+
   def test_snippet_with_unclosed_backtick
     source = <<~SOURCE
       # Code example:


### PR DESCRIPTION
## What

Allows linting of markdown-blocks with "metadata" after the syntax declaration, eg:

```md
```ruby example_name
class Test < Minitest::Test
  def test_valid
    assert false
  end
end
...
```

## Why

While I recognize entirely that having something after the syntax declaration isn't exactly a standard, there are [some examples out there](https://mdxjs.com/guides/syntax-highlighting/#syntax-highlighting-with-the-meta-field) of this kind of usage.

Personally, I'm working on a project that uses this approach to extract code samples for inclusion into SDK documentation, using the metadata to map code blocks to the correct parts of the docs, and I hope it makes sense to add support for that scenario! 🙏 