### PR TITLE
Update `get_processed_source` to accept keyword arguments

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -13,7 +13,6 @@ AllCops:
     - '*.gemspec'
   DisplayCopNames: true
   StyleGuideCopsOnly: false
-  TargetRubyVersion: 2.6
   SuggestExtensions: false
 
 Style/Documentation:

--- a/lib/rubocop/markdown/rubocop_ext.rb
+++ b/lib/rubocop/markdown/rubocop_ext.rb
@@ -33,7 +33,7 @@ end
 
 RuboCop::Runner.prepend(Module.new do
   # Set config store for Markdown
-  def get_processed_source(*args, **kwargs)
+  def get_processed_source(...)
     RuboCop::Markdown.config_store = @config_store unless RuboCop::Markdown.config_store
 
     super
@@ -41,13 +41,13 @@ RuboCop::Runner.prepend(Module.new do
 
   # Do not cache markdown files, 'cause cache doesn't know about processing.
   # NOTE: we should involve preprocessing in RuboCop::CachedData#deserialize_offenses
-  def file_offense_cache(file, *args, **kwargs)
+  def file_offense_cache(file, ...)
     return yield if RuboCop::Markdown.markdown_file?(file)
 
     super
   end
 
-  def file_finished(file, offenses, *args, **kwargs)
+  def file_finished(file, offenses, ...)
     return super unless RuboCop::Markdown.markdown_file?(file)
 
     # Run Preprocess.restore if file has been autocorrected
@@ -75,14 +75,14 @@ end)
 
 # Allow Rubocop to analyze markdown files
 RuboCop::TargetFinder.prepend(Module.new do
-  def ruby_file?(file, *args, **kwargs)
+  def ruby_file?(file, ...)
     super || RuboCop::Markdown.markdown_file?(file)
   end
 end)
 
 # Extend ProcessedSource#parse with pre-processing
 RuboCop::ProcessedSource.prepend(Module.new do
-  def parse(src, *args, **kwargs)
+  def parse(src, ...)
     # only process Markdown files
     src = RuboCop::Markdown::Preprocess.new(path).call(src) if
       path && RuboCop::Markdown.markdown_file?(path)

--- a/lib/rubocop/markdown/rubocop_ext.rb
+++ b/lib/rubocop/markdown/rubocop_ext.rb
@@ -41,13 +41,13 @@ RuboCop::Runner.prepend(Module.new do
 
   # Do not cache markdown files, 'cause cache doesn't know about processing.
   # NOTE: we should involve preprocessing in RuboCop::CachedData#deserialize_offenses
-  def file_offense_cache(file)
+  def file_offense_cache(file, *args, **kwargs)
     return yield if RuboCop::Markdown.markdown_file?(file)
 
     super
   end
 
-  def file_finished(file, offenses)
+  def file_finished(file, offenses, *args, **kwargs)
     return super unless RuboCop::Markdown.markdown_file?(file)
 
     # Run Preprocess.restore if file has been autocorrected
@@ -75,14 +75,14 @@ end)
 
 # Allow Rubocop to analyze markdown files
 RuboCop::TargetFinder.prepend(Module.new do
-  def ruby_file?(file)
+  def ruby_file?(file, *args, **kwargs)
     super || RuboCop::Markdown.markdown_file?(file)
   end
 end)
 
 # Extend ProcessedSource#parse with pre-processing
 RuboCop::ProcessedSource.prepend(Module.new do
-  def parse(src, *args)
+  def parse(src, *args, **kwargs)
     # only process Markdown files
     src = RuboCop::Markdown::Preprocess.new(path).call(src) if
       path && RuboCop::Markdown.markdown_file?(path)

--- a/lib/rubocop/markdown/rubocop_ext.rb
+++ b/lib/rubocop/markdown/rubocop_ext.rb
@@ -33,7 +33,7 @@ end
 
 RuboCop::Runner.prepend(Module.new do
   # Set config store for Markdown
-  def get_processed_source(*args)
+  def get_processed_source(*args, **kwargs)
     RuboCop::Markdown.config_store = @config_store unless RuboCop::Markdown.config_store
 
     super


### PR DESCRIPTION
Follow-up to https://github.com/rubocop/rubocop/pull/14478

The `get_processed_source` method has been updated to have a `prism_result:` keyword argument, so in this repo it must be modified to support passing keyword arguments along via `super`.

I'm not sure how `rubocop-md` releases align with `rubocop` releases, but I think this change should be safe to be released independently of a new `rubocop` release as the change just enables keyword arguments but doesn't require them.
